### PR TITLE
Add basic FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # codex_example
+
+This is a minimal FastAPI project skeleton.
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# FastAPI app package

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+# API package

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+# v1 package

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,1 @@
+# endpoints package

--- a/app/api/v1/endpoints/health.py
+++ b/app/api/v1/endpoints/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+async def health_check():
+    return {"status": "ok"}
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+
+from .api.v1.endpoints import health
+
+app = FastAPI()
+
+app.include_router(health.router)
+
+@app.get("/")
+async def root():
+    return {"message": "Hello, World!"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, World!"}
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- set up a minimal FastAPI project layout
- add root and health endpoints
- provide example tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847133507788325a433e83825a07799