### PR TITLE
Add CRUD routes

### DIFF
--- a/app/api/v1/endpoints/books.py
+++ b/app/api/v1/endpoints/books.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ....database import get_db
+from ....models import Book
+from ....schemas.book import BookCreate, BookRead, BookUpdate
+
+router = APIRouter(prefix="/books", tags=["books"])
+
+
+@router.get("/", response_model=list[BookRead])
+def read_books(db: Session = Depends(get_db)):
+    return db.query(Book).all()
+
+
+@router.post("/", response_model=BookRead, status_code=201)
+def create_book(book: BookCreate, db: Session = Depends(get_db)):
+    db_book = Book(**book.dict())
+    db.add(db_book)
+    db.commit()
+    db.refresh(db_book)
+    return db_book
+
+
+@router.get("/{book_id}", response_model=BookRead)
+def read_book(book_id: int, db: Session = Depends(get_db)):
+    book = db.query(Book).get(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book
+
+
+@router.put("/{book_id}", response_model=BookRead)
+def update_book(book_id: int, book_update: BookUpdate, db: Session = Depends(get_db)):
+    book = db.query(Book).get(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    update_data = book_update.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(book, key, value)
+    db.commit()
+    db.refresh(book)
+    return book
+
+
+@router.delete("/{book_id}", status_code=204)
+def delete_book(book_id: int, db: Session = Depends(get_db)):
+    book = db.query(Book).get(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    db.delete(book)
+    db.commit()
+    return None

--- a/app/api/v1/endpoints/loans.py
+++ b/app/api/v1/endpoints/loans.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ....database import get_db
+from ....models import Loan
+from ....schemas.loan import LoanCreate, LoanRead, LoanUpdate
+
+router = APIRouter(prefix="/loans", tags=["loans"])
+
+
+@router.get("/", response_model=list[LoanRead])
+def read_loans(db: Session = Depends(get_db)):
+    return db.query(Loan).all()
+
+
+@router.post("/", response_model=LoanRead, status_code=201)
+def create_loan(loan: LoanCreate, db: Session = Depends(get_db)):
+    db_loan = Loan(member_id=loan.member_id, book_id=loan.book_id)
+    db.add(db_loan)
+    db.commit()
+    db.refresh(db_loan)
+    return db_loan
+
+
+@router.get("/{loan_id}", response_model=LoanRead)
+def read_loan(loan_id: int, db: Session = Depends(get_db)):
+    loan = db.query(Loan).get(loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    return loan
+
+
+@router.put("/{loan_id}", response_model=LoanRead)
+def update_loan(loan_id: int, loan_update: LoanUpdate, db: Session = Depends(get_db)):
+    loan = db.query(Loan).get(loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    update_data = loan_update.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(loan, key, value)
+    db.commit()
+    db.refresh(loan)
+    return loan
+
+
+@router.delete("/{loan_id}", status_code=204)
+def delete_loan(loan_id: int, db: Session = Depends(get_db)):
+    loan = db.query(Loan).get(loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    db.delete(loan)
+    db.commit()
+    return None

--- a/app/api/v1/endpoints/members.py
+++ b/app/api/v1/endpoints/members.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ....database import get_db
+from ....models import Member
+from ....schemas.member import MemberCreate, MemberRead, MemberUpdate
+
+router = APIRouter(prefix="/members", tags=["members"])
+
+
+@router.get("/", response_model=list[MemberRead])
+def read_members(db: Session = Depends(get_db)):
+    return db.query(Member).all()
+
+
+@router.post("/", response_model=MemberRead, status_code=201)
+def create_member(member: MemberCreate, db: Session = Depends(get_db)):
+    db_member = Member(**member.dict())
+    db.add(db_member)
+    db.commit()
+    db.refresh(db_member)
+    return db_member
+
+
+@router.get("/{member_id}", response_model=MemberRead)
+def read_member(member_id: int, db: Session = Depends(get_db)):
+    member = db.query(Member).get(member_id)
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return member
+
+
+@router.put("/{member_id}", response_model=MemberRead)
+def update_member(member_id: int, member_update: MemberUpdate, db: Session = Depends(get_db)):
+    member = db.query(Member).get(member_id)
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found")
+    update_data = member_update.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(member, key, value)
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+@router.delete("/{member_id}", status_code=204)
+def delete_member(member_id: int, db: Session = Depends(get_db)):
+    member = db.query(Member).get(member_id)
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found")
+    db.delete(member)
+    db.commit()
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,14 @@
 from fastapi import FastAPI
 
 from .api.v1.endpoints import health
+from .api.v1.endpoints import members, books, loans
 
 app = FastAPI()
 
 app.include_router(health.router)
+app.include_router(members.router)
+app.include_router(books.router)
+app.include_router(loans.router)
 
 @app.get("/")
 async def root():

--- a/app/schemas/book.py
+++ b/app/schemas/book.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class BookBase(BaseModel):
+    title: str
+    author: str
+    total_copies: int
+
+
+class BookCreate(BookBase):
+    pass
+
+
+class BookUpdate(BaseModel):
+    title: Optional[str] = None
+    author: Optional[str] = None
+    total_copies: Optional[int] = None
+
+
+class BookRead(BookBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/loan.py
+++ b/app/schemas/loan.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+
+class LoanBase(BaseModel):
+    member_id: int
+    book_id: int
+    loan_date: Optional[datetime] = None
+    return_date: Optional[datetime] = None
+
+
+class LoanCreate(BaseModel):
+    member_id: int
+    book_id: int
+
+
+class LoanUpdate(BaseModel):
+    return_date: Optional[datetime] = None
+
+
+class LoanRead(LoanBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/member.py
+++ b/app/schemas/member.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class MemberBase(BaseModel):
+    name: str
+    email: str
+
+
+class MemberCreate(MemberBase):
+    pass
+
+
+class MemberUpdate(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+
+class MemberRead(MemberBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- scaffold Pydantic schemas for Member, Book and Loan
- implement CRUD API routes for each model
- register new routes in FastAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c977178e88325ac006e8fe589e1c5