### PR TITLE
Allow filtering in list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a minimal FastAPI project skeleton.
 
+The list endpoints for books, members and loans support optional query
+parameters that act as filters. For example, you can filter books by title or
+author, members by name or email and loans by member id, book id or whether the
+loan has been returned.
+
 ## Development
 
 Install dependencies:

--- a/app/api/v1/endpoints/books.py
+++ b/app/api/v1/endpoints/books.py
@@ -9,8 +9,17 @@ router = APIRouter(prefix="/books", tags=["books"])
 
 
 @router.get("/", response_model=list[BookRead])
-def read_books(db: Session = Depends(get_db)):
-    return db.query(Book).all()
+def read_books(
+    title: str | None = None,
+    author: str | None = None,
+    db: Session = Depends(get_db),
+):
+    query = db.query(Book)
+    if title:
+        query = query.filter(Book.title.ilike(f"%{title}%"))
+    if author:
+        query = query.filter(Book.author.ilike(f"%{author}%"))
+    return query.all()
 
 
 @router.post("/", response_model=BookRead, status_code=201)

--- a/app/api/v1/endpoints/loans.py
+++ b/app/api/v1/endpoints/loans.py
@@ -9,8 +9,23 @@ router = APIRouter(prefix="/loans", tags=["loans"])
 
 
 @router.get("/", response_model=list[LoanRead])
-def read_loans(db: Session = Depends(get_db)):
-    return db.query(Loan).all()
+def read_loans(
+    member_id: int | None = None,
+    book_id: int | None = None,
+    returned: bool | None = None,
+    db: Session = Depends(get_db),
+):
+    query = db.query(Loan)
+    if member_id is not None:
+        query = query.filter(Loan.member_id == member_id)
+    if book_id is not None:
+        query = query.filter(Loan.book_id == book_id)
+    if returned is not None:
+        if returned:
+            query = query.filter(Loan.return_date.isnot(None))
+        else:
+            query = query.filter(Loan.return_date.is_(None))
+    return query.all()
 
 
 @router.post("/", response_model=LoanRead, status_code=201)

--- a/app/api/v1/endpoints/members.py
+++ b/app/api/v1/endpoints/members.py
@@ -9,8 +9,17 @@ router = APIRouter(prefix="/members", tags=["members"])
 
 
 @router.get("/", response_model=list[MemberRead])
-def read_members(db: Session = Depends(get_db)):
-    return db.query(Member).all()
+def read_members(
+    name: str | None = None,
+    email: str | None = None,
+    db: Session = Depends(get_db),
+):
+    query = db.query(Member)
+    if name:
+        query = query.filter(Member.name.ilike(f"%{name}%"))
+    if email:
+        query = query.filter(Member.email.ilike(f"%{email}%"))
+    return query.all()
 
 
 @router.post("/", response_model=MemberRead, status_code=201)


### PR DESCRIPTION
## Summary
- add query parameter filtering for books, members and loans
- document filtering support in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9ab22a388325b029060baa183073